### PR TITLE
Added os identification to crypto gradle build

### DIFF
--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -12,20 +12,26 @@ test {
 
 task compileRust {
     doLast {
-// TODO 'MasOS support problem'. Uncomment it and adjust compiler or consider another approach to get compiled libraries.
-//        exec {
-//            workingDir 'src/jni-crypto'
-//            commandLine 'cargo', 'build', '--release', '--target=x86_64-apple-darwin', '--target-dir=../../build/jni-crypto'
-//        }
-        exec {
-            workingDir 'src/jni-crypto'
-            commandLine 'cargo', 'build', '--release', '--target=x86_64-unknown-linux-gnu', '--target-dir=../../build/jni-crypto'
+        if(System.getProperty("os.name").toLowerCase().contains("linux")) {
+            exec {
+                workingDir 'src/jni-crypto'
+                commandLine 'cargo', 'build', '--release', '--target=x86_64-unknown-linux-gnu', '--target-dir=../../build/jni-crypto'
+            }
         }
-// TODO the build of the native library will be moved out of the project
-//        exec {
-//            workingDir 'src/jni-crypto'
-//            commandLine 'cargo', 'build', '--release', '--target=x86_64-pc-windows-gnu', '--target-dir=../../build/jni-crypto'
-//        }
+        else if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            exec {
+                workingDir 'src/jni-crypto'
+                commandLine 'cargo', 'build', '--release', '--target=x86_64-pc-windows-gnu', '--target-dir=../../build/jni-crypto'
+            }
+        }
+        // Does not cover solaris, just MacOS. See potential return types here:
+        // https://docs.gradle.org/current/javadoc/org/gradle/nativeplatform/platform/OperatingSystem.html
+        else {
+            exec {
+                workingDir 'src/jni-crypto'
+                commandLine 'cargo', 'build', '--release', '--target=x86_64-apple-darwin', '--target-dir=../../build/jni-crypto'
+            }
+        }
     }
 }
 


### PR DESCRIPTION
In the crypto build.gradle file you used to have to comment in/out the right os for building.
This should automatically identify your os now.