### PR TITLE
Update Utility, Balances, Collator Selection, Council, Session, Techn…

### DIFF
--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/authorship/Authorship.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/authorship/Authorship.java
@@ -1,0 +1,7 @@
+package com.strategyobject.substrateclient.api.pallet.authorship;
+
+public interface Authorship {
+    /**
+     * This tracks the current author of the block and recent uncles.
+     */
+}

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/balances/Balances.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/balances/Balances.java
@@ -62,7 +62,7 @@ public interface Balances {
         private Balance free;
         private Balance reserved;
     }
-
+    
     /**
      * Some amount was deposited (e.g. for transaction fees). \[who, deposit\]
      */

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/balances/Balances.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/balances/Balances.java
@@ -62,18 +62,6 @@ public interface Balances {
         private Balance free;
         private Balance reserved;
     }
-    
-    /**
-     * Some amount was deposited (e.g. for transaction fees). \[who, deposit\]
-     */
-    @Event(index = 7)
-    @Getter
-    @Setter
-    @ScaleReader
-    class Deposit {
-        private AccountId account;
-        private Balance value;
-    }
 
     /**
      * Some balance was reserved (moved from free to reserved). \[who, value\]
@@ -115,6 +103,22 @@ public interface Balances {
         private BalanceStatus destinationStatus;
     }
 
+    /**
+     * Some amount was deposited (e.g. for transaction fees). \[who, deposit\]
+     */
+    @Event(index = 7)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Deposit {
+        private AccountId account;
+        private Balance value;
+    }
+
+    /**
+     * Some amount was withdrawn from the account (e.g. for transaction fees).
+     */
+
     @Event(index = 8)
     @Getter
     @Setter
@@ -123,6 +127,10 @@ public interface Balances {
         private AccountId account;
         private Balance value;
     }
+
+    /**
+     * Some amount was removed from the account (e.g. for misbehavior).
+     */
 
     @Event(index = 9)
     @Getter

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/collator_selection/CollatorSelection.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/collator_selection/CollatorSelection.java
@@ -1,6 +1,7 @@
 package com.strategyobject.substrateclient.api.pallet.collator_selection;
 
 import com.strategyobject.substrateclient.pallet.annotation.Event;
+import com.strategyobject.substrateclient.pallet.annotation.Pallet;
 import com.strategyobject.substrateclient.rpc.api.AccountId;
 import com.strategyobject.substrateclient.rpc.api.primitives.Balance;
 import com.strategyobject.substrateclient.scale.ScaleType;
@@ -11,6 +12,7 @@ import lombok.Setter;
 
 import java.util.List;
 
+@Pallet("CollatorSelection")
 public interface CollatorSelection {
     @Event(index = 0)
     @Getter

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/collator_selection/CollatorSelection.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/collator_selection/CollatorSelection.java
@@ -1,0 +1,57 @@
+package com.strategyobject.substrateclient.api.pallet.collator_selection;
+
+import com.strategyobject.substrateclient.pallet.annotation.Event;
+import com.strategyobject.substrateclient.rpc.api.AccountId;
+import com.strategyobject.substrateclient.rpc.api.primitives.Balance;
+import com.strategyobject.substrateclient.scale.ScaleType;
+import com.strategyobject.substrateclient.scale.annotation.Scale;
+import com.strategyobject.substrateclient.scale.annotation.ScaleReader;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public interface CollatorSelection {
+    @Event(index = 0)
+    @Getter
+    @Setter
+    @ScaleReader
+    class NewInvulnerables {
+        @Scale(ScaleType.Vec.class)
+        private List<AccountId> invulnerables;
+    }
+
+    @Event(index = 1)
+    @Getter
+    @Setter
+    @ScaleReader
+    class NewDesiredCandidates {
+        @Scale(ScaleType.U32.class)
+        private Long desiredCandidates;
+    }
+
+    @Event(index = 2)
+    @Getter
+    @Setter
+    @ScaleReader
+    class NewCandidacyBond {
+        private Balance bondAmount;
+    }
+
+    @Event(index = 3)
+    @Getter
+    @Setter
+    @ScaleReader
+    class CandidateAdded {
+        private AccountId accountId;
+        private Balance deposit;
+    }
+
+    @Event(index = 4)
+    @Getter
+    @Setter
+    @ScaleReader
+    class CandidateRemoved {
+        private AccountId accountId;
+    }
+}

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/council/Council.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/council/Council.java
@@ -1,0 +1,113 @@
+package com.strategyobject.substrateclient.api.pallet.council;
+
+
+import com.strategyobject.substrateclient.common.types.Result;
+import com.strategyobject.substrateclient.common.types.Unit;
+import com.strategyobject.substrateclient.pallet.annotation.Event;
+import com.strategyobject.substrateclient.pallet.annotation.Pallet;
+import com.strategyobject.substrateclient.rpc.api.AccountId;
+import com.strategyobject.substrateclient.rpc.api.primitives.Hash;
+import com.strategyobject.substrateclient.rpc.api.runtime.DispatchError;
+import com.strategyobject.substrateclient.scale.ScaleType;
+import com.strategyobject.substrateclient.scale.annotation.Scale;
+import com.strategyobject.substrateclient.scale.annotation.ScaleReader;
+import lombok.Getter;
+import lombok.Setter;
+
+@Pallet("Council")
+public interface Council {
+    /**
+     * A motion (given hash) has been proposed (by given account) with a threshold (given MemberCount).
+     */
+    @Event(index = 0)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Proposed {
+        private AccountId account;
+        @Scale(ScaleType.U32.class)
+        private Long proposalIndex;
+        private Hash proposalHash;
+        @Scale(ScaleType.U32.class)
+        private Long threshold;
+    }
+
+    /**
+     *  A motion (given hash) has been voted on by given account, leaving
+     *  a tally (yes votes and no votes given respectively as `MemberCount`).
+     */
+    @Event(index = 1)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Voted {
+        private AccountId account;
+        private Hash proposalHash;
+        private Boolean voted;
+        @Scale(ScaleType.U32.class)
+        private Long votedYes;
+        @Scale(ScaleType.U32.class)
+        private Long votedNo;
+    }
+
+    /**
+     * A motion was approved by the required threshold.
+     */
+    @Event(index = 2)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Approved {
+        private Hash proposalHash;
+    }
+
+    /**
+     * A motion was not approved by the required threshold.
+     */
+    @Event(index = 3)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Disapproved {
+        private Hash proposalHash;
+    }
+
+    /**
+     * A motion was executed; result will be `Ok` if it returned without error.
+     */
+    @Event(index = 4)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Executed {
+        private Hash proposalHash;
+        private Result<Unit, DispatchError> result;
+    }
+
+    /**
+     * A single member did some action; result will be `Ok` if it returned without error.
+     */
+    @Event(index = 5)
+    @Getter
+    @Setter
+    @ScaleReader
+    class MemberExecuted {
+        private Hash proposalHash;
+        private Result<Unit, DispatchError> result;
+    }
+
+    /**
+     * A proposal was closed because its threshold was reached or after its duration was up.
+     */
+    @Event(index = 6)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Closed {
+        private Hash proposalHash;
+        @Scale(ScaleType.U32.class)
+        private Long votedYesCount;
+        @Scale(ScaleType.U32.class)
+        private Long votedNoCount;
+    }
+}

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/council/Council.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/council/Council.java
@@ -43,6 +43,7 @@ public interface Council {
     class Voted {
         private AccountId account;
         private Hash proposalHash;
+        @Scale(ScaleType.Bool.class)
         private Boolean voted;
         @Scale(ScaleType.U32.class)
         private Long votedYes;

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/technical_committee/TechnicalCommittee.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/technical_committee/TechnicalCommittee.java
@@ -1,0 +1,112 @@
+package com.strategyobject.substrateclient.api.pallet.technical_committee;
+
+import com.strategyobject.substrateclient.common.types.Result;
+import com.strategyobject.substrateclient.common.types.Unit;
+import com.strategyobject.substrateclient.pallet.annotation.Event;
+import com.strategyobject.substrateclient.pallet.annotation.Pallet;
+import com.strategyobject.substrateclient.rpc.api.AccountId;
+import com.strategyobject.substrateclient.rpc.api.primitives.Hash;
+import com.strategyobject.substrateclient.rpc.api.runtime.DispatchError;
+import com.strategyobject.substrateclient.scale.ScaleType;
+import com.strategyobject.substrateclient.scale.annotation.Scale;
+import com.strategyobject.substrateclient.scale.annotation.ScaleReader;
+import lombok.Getter;
+import lombok.Setter;
+
+@Pallet("TechnicalCommittee")
+public interface TechnicalCommittee {
+    /**
+     * A motion (given hash) has been proposed (by given account) with a threshold (given MemberCount).
+     */
+    @Event(index = 0)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Proposed {
+        private AccountId account;
+        @Scale(ScaleType.U32.class)
+        private Long proposalIndex;
+        private Hash proposalHash;
+        @Scale(ScaleType.U32.class)
+        private Long threshold;
+    }
+
+    /**
+     *  A motion (given hash) has been voted on by given account, leaving
+     *  a tally (yes votes and no votes given respectively as `MemberCount`).
+     */
+    @Event(index = 1)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Voted {
+        private AccountId account;
+        private Hash proposalHash;
+        private Boolean voted;
+        @Scale(ScaleType.U32.class)
+        private Long votedYes;
+        @Scale(ScaleType.U32.class)
+        private Long votedNo;
+    }
+
+    /**
+     * A motion was approved by the required threshold.
+     */
+    @Event(index = 2)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Approved {
+        private Hash proposalHash;
+    }
+
+    /**
+     * A motion was not approved by the required threshold.
+     */
+    @Event(index = 3)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Disapproved {
+        private Hash proposalHash;
+    }
+
+    /**
+     * A motion was executed; result will be `Ok` if it returned without error.
+     */
+    @Event(index = 4)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Executed {
+        private Hash proposalHash;
+        private Result<Unit, DispatchError> result;
+    }
+
+    /**
+     * A single member did some action; result will be `Ok` if it returned without error.
+     */
+    @Event(index = 5)
+    @Getter
+    @Setter
+    @ScaleReader
+    class MemberExecuted {
+        private Hash proposalHash;
+        private Result<Unit, DispatchError> result;
+    }
+
+    /**
+     * A proposal was closed because its threshold was reached or after its duration was up.
+     */
+    @Event(index = 6)
+    @Getter
+    @Setter
+    @ScaleReader
+    class Closed {
+        private Hash proposalHash;
+        @Scale(ScaleType.U32.class)
+        private Long votedYesCount;
+        @Scale(ScaleType.U32.class)
+        private Long votedNoCount;
+    }
+}

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/technical_committee/TechnicalCommittee.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/technical_committee/TechnicalCommittee.java
@@ -42,6 +42,7 @@ public interface TechnicalCommittee {
     class Voted {
         private AccountId account;
         private Hash proposalHash;
+        @Scale(ScaleType.Bool.class)
         private Boolean voted;
         @Scale(ScaleType.U32.class)
         private Long votedYes;

--- a/api/src/main/java/com/strategyobject/substrateclient/api/pallet/utility/Utility.java
+++ b/api/src/main/java/com/strategyobject/substrateclient/api/pallet/utility/Utility.java
@@ -1,5 +1,6 @@
 package com.strategyobject.substrateclient.api.pallet.utility;
 
+import com.strategyobject.substrateclient.common.types.Result;
 import com.strategyobject.substrateclient.pallet.annotation.Event;
 import com.strategyobject.substrateclient.pallet.annotation.Pallet;
 import com.strategyobject.substrateclient.rpc.api.runtime.DispatchError;
@@ -8,6 +9,7 @@ import com.strategyobject.substrateclient.scale.annotation.Scale;
 import com.strategyobject.substrateclient.scale.annotation.ScaleReader;
 import lombok.Getter;
 import lombok.Setter;
+import com.strategyobject.substrateclient.common.types.Unit;
 
 @Pallet("Utility")
 public interface Utility {
@@ -35,11 +37,40 @@ public interface Utility {
     }
 
     /**
+     * Batch of dispatches completed but has errors.
+     */
+    @Event(index=2)
+    @ScaleReader
+    class BatchCompletedWithErrors {
+    }
+
+    /**
      * A single item within a Batch of dispatches has completed with no error.
      */
-    @Event(index = 2)
+    @Event(index = 3)
     @ScaleReader
     class ItemCompleted {
     }
 
+    /**
+     * A single item within a Batch of dispatches has completed with error.
+     */
+    @Event(index=4)
+    @Getter
+    @Setter
+    @ScaleReader
+    class ItemFailed {
+        private DispatchError dispatchError;
+    }
+
+    /**
+     * A call was dispatched.
+     */
+    @Event(index=5)
+    @Getter
+    @Setter
+    @ScaleReader
+    class DispatchedAs {
+        private Result<Unit, DispatchError> result;
+    }
 }


### PR DESCRIPTION
Authorship doesn't have any events

Line 21 of the Collator Selection pallet has this so I surmised it was a list of AccountIds:
                        {
                          name: invulnerables
                          type: 34
                          typeName: Vec&lt;T::AccountId&gt;
                          docs: []
                        }