### PR TITLE
Added some capabilities for previously unmapped calls

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -15,6 +15,8 @@ jobs:
       packages: write
 
     steps:
+      - name: Output GLIBC Version
+        run: ldd --version
       - uses: actions/checkout@v3
       - name: Set up JDK 8
         uses: actions/setup-java@v3

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/AccountIdScaleWrapper.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/AccountIdScaleWrapper.java
@@ -1,0 +1,24 @@
+package com.strategyobject.substrateclient.rpc.api;
+
+import com.strategyobject.substrateclient.scale.annotation.ScaleWriter;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * The reality is this should just be an AccountId but in the spirit of Jenga code I'd rather wrap it. I would have just
+ * called this AddressId but that exists and THAT class SHOULD be called MultiAddress but I don't want to mess up
+ * downstream consumers by just refactoring in place
+ */
+@Getter
+@ScaleWriter
+public class AccountIdScaleWrapper {
+  private final AccountId address;
+
+  private AccountIdScaleWrapper(@NonNull AccountId address) {
+    this.address = address;
+  }
+
+  public static AccountIdScaleWrapper fromBytes(byte @NonNull [] accountId) {
+    return new AccountIdScaleWrapper(AccountId.fromBytes(accountId));
+  }
+}

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/RuntimeVersion.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/RuntimeVersion.java
@@ -1,7 +1,15 @@
 package com.strategyobject.substrateclient.rpc.api;
 
 import com.strategyobject.substrateclient.rpc.annotation.RpcDecoder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @RpcDecoder
+@NoArgsConstructor
+@Getter
+@Setter
 public class RuntimeVersion {
+  private Long specVersion;
+  private Long transactionVersion;
 }

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/primitives/Index.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/primitives/Index.java
@@ -10,7 +10,11 @@ import lombok.RequiredArgsConstructor;
 import java.math.BigInteger;
 
 /**
- * Index of a transaction in the chain.
+ * Index of a transaction in the chain. Sadly it seems thew Index that is sent in an extrinsic needs to be a CompactBigInteger, however, the SCALE encoding
+ * for an Index coming from the AccountNonceApi_account_nonce is a U32 hence the need for 2 different class depending on
+ * context
+ *
+ * @see IndexU32
  */
 @RequiredArgsConstructor(staticName = "of")
 @Getter
@@ -24,5 +28,13 @@ public class Index {
 
     public static Index of(long value) {
         return of(BigInteger.valueOf(value));
+    }
+
+    public IndexU32 toIndexU32(){
+        return IndexU32.fromIndex(this);
+    }
+
+    public Index fromIndexU32(IndexU32 indexU32) {
+        return Index.of(indexU32.getValue());
     }
 }

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/primitives/IndexU32.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/primitives/IndexU32.java
@@ -1,0 +1,46 @@
+package com.strategyobject.substrateclient.rpc.api.primitives;
+
+import com.strategyobject.substrateclient.scale.ScaleType;
+import com.strategyobject.substrateclient.scale.annotation.Scale;
+import com.strategyobject.substrateclient.scale.annotation.ScaleReader;
+
+/**
+ * Sadly it seems thew Index that is sent in an extrinsic needs to be a CompactBigInteger, however, the SCALE encoding
+ * for an Index coming from the AccountNonceApi_account_nonce is a U32 hence the need for 2 different class depending on
+ * context
+ *
+ * @see Index
+ */
+@ScaleReader
+public class IndexU32 {
+  @Scale(ScaleType.U32.class)
+  private Long value;
+
+  public IndexU32(){
+
+  }
+
+  public IndexU32(Long value){
+    this.value = value;
+  }
+
+  public Long getValue() {
+    return value;
+  }
+
+  public void setValue(Long value) {
+    this.value = value;
+  }
+
+  public static IndexU32 of(Long value){
+    return new IndexU32(value);
+  }
+
+  public Index toIndex(){
+    return Index.of(value);
+  }
+
+  public static IndexU32 fromIndex(Index index){
+    return IndexU32.of(index.getValue().longValue());
+  }
+}

--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/section/State.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/section/State.java
@@ -6,6 +6,7 @@ import com.strategyobject.substrateclient.rpc.annotation.RpcSubscription;
 import com.strategyobject.substrateclient.rpc.api.*;
 import com.strategyobject.substrateclient.rpc.api.primitives.BlockHash;
 import com.strategyobject.substrateclient.rpc.api.primitives.Hash;
+import com.strategyobject.substrateclient.rpc.api.primitives.IndexU32;
 import com.strategyobject.substrateclient.rpc.api.storage.StorageChangeSet;
 import com.strategyobject.substrateclient.rpc.api.storage.StorageData;
 import com.strategyobject.substrateclient.rpc.api.storage.StorageKey;
@@ -223,4 +224,8 @@ public interface State {
     @RpcSubscription(type = "storage", subscribeMethod = "subscribeStorage", unsubscribeMethod = "unsubscribeStorage")
     CompletableFuture<Supplier<CompletableFuture<Boolean>>> subscribeStorage(List<StorageKey> keys,
                                                                              BiConsumer<Exception, StorageChangeSet> callback);
+
+    @RpcCall("call")
+    @Scale
+    CompletableFuture<IndexU32> retrieveAccountNonce(String method, @Scale AccountIdScaleWrapper addressId);
 }

--- a/rpc/rpc-api/src/test/resources/logback.xml
+++ b/rpc/rpc-api/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>


### PR DESCRIPTION
Specifically the call to get the account nonce in order to make sure our Extrinsics are properly initialized without needing magic values on startup and also grabbing the Runtime version for the spec and transaction versions that are needed for extrinsics