### PR TITLE
Now using a wrapper for Broadcast

### DIFF
--- a/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/ExtrinsicStatus.java
+++ b/rpc/rpc-api/src/main/java/com/strategyobject/substrateclient/rpc/api/ExtrinsicStatus.java
@@ -49,8 +49,8 @@ public interface ExtrinsicStatus {
     @Setter
     @RpcDecoder
     class Broadcast implements ExtrinsicStatus {
-        @Scale
-        private List<String> broadcast;
+
+        private List<BroadcastScale> broadcast;
 
         @Override
         public Status getStatus() {

--- a/transport/build.gradle
+++ b/transport/build.gradle
@@ -3,7 +3,9 @@ dependencies {
 
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
     implementation 'com.google.code.gson:gson:2.9.0'
+    implementation project(':scale')
 
+    annotationProcessor project(':scale:scale-codegen')
     testImplementation project(':tests')
     testImplementation 'org.testcontainers:testcontainers:1.17.3'
     testImplementation 'org.testcontainers:junit-jupiter:1.17.3'

--- a/transport/src/main/java/com/strategyobject/substrateclient/rpc/api/BroadcastScale.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/rpc/api/BroadcastScale.java
@@ -1,0 +1,16 @@
+package com.strategyobject.substrateclient.rpc.api;
+
+import com.strategyobject.substrateclient.scale.annotation.Scale;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.lang.reflect.Type;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BroadcastScale {
+  @Scale
+  private String value;
+}

--- a/transport/src/main/java/com/strategyobject/substrateclient/rpc/api/BroadcastScaleFactory.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/rpc/api/BroadcastScaleFactory.java
@@ -1,0 +1,15 @@
+package com.strategyobject.substrateclient.rpc.api;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+public class BroadcastScaleFactory  implements JsonDeserializer<BroadcastScale> {
+  @Override
+  public BroadcastScale deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+    return new BroadcastScale(json.getAsString());
+  }
+}

--- a/transport/src/main/java/com/strategyobject/substrateclient/transport/coder/RpcCoder.java
+++ b/transport/src/main/java/com/strategyobject/substrateclient/transport/coder/RpcCoder.java
@@ -2,6 +2,8 @@ package com.strategyobject.substrateclient.transport.coder;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.strategyobject.substrateclient.rpc.api.BroadcastScale;
+import com.strategyobject.substrateclient.rpc.api.BroadcastScaleFactory;
 import com.strategyobject.substrateclient.transport.RpcObject;
 
 import java.util.List;
@@ -10,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class RpcCoder {
     private static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(RpcObject.class, new RpcObjectTypeAdapter())
+            .registerTypeAdapter(BroadcastScale.class, new BroadcastScaleFactory())
             .create();
 
     private final AtomicInteger id = new AtomicInteger(0);


### PR DESCRIPTION
This was needed because the autogen code was coercing the list to a string which isn't the intent, it need to coalesce the elements to strings that are SCALE based, this introducers a wrapper that will ... maybe fix that