### PR TITLE
Fix/Arm mac support

### DIFF
--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -30,7 +30,7 @@ task compileRust {
         else {
             exec {
                 workingDir 'src/jni-crypto'
-                commandLine 'cargo', 'build', '--release', '--target=x86_64-apple-darwin', '--target-dir=../../build/jni-crypto'
+                commandLine 'cargo', 'build', '--release', '--target-dir=../../build/jni-crypto'
             }
         }
     }
@@ -39,7 +39,7 @@ task compileRust {
 compileJava.dependsOn(compileRust)
 
 processResources {
-    from("${buildDir}/jni-crypto/x86_64-apple-darwin/release") {
+    from("${buildDir}/jni-crypto/release") {
         into "include/macos"
         include '*.dylib'
     }


### PR DESCRIPTION
I noticed issues building this repo on my M2 mac that are fixed by these changes. There is a possibility that these changes may impact Haswell Intel Macs—which will now target `x86_64h` instead of `x86_64`—but it should not change behavior (although may increase performance).

I'm looking for at least 1-2 folks to test this branch out on different machines before merging. Thanks!