### PR TITLE
186828135: Moves exception into `CompletableFuture` context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build/
 ### Gradle ###
 .gradle
 build/
+bin/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/WsProviderTest.java
+++ b/transport/src/test/java/com/strategyobject/substrateclient/transport/ws/WsProviderTest.java
@@ -158,6 +158,21 @@ class WsProviderTest {
 
     @Test
     @SneakyThrows
+    void sendWhileDisconnectedThrows() {
+        try (val wsProvider = WsProvider.builder()
+                .setEndpoint(substrate.getWsAddress())
+                .withPolicy(ReconnectionPolicy.MANUAL)
+                .build()) {
+
+            val executionException = assertThrows(
+                    ExecutionException.class,
+                    () -> wsProvider.send("unknown_method", null).get(WAIT_TIMEOUT, TimeUnit.SECONDS));
+            assertTrue(executionException.getCause() instanceof IllegalStateException);
+        }
+    }
+
+    @Test
+    @SneakyThrows
     @Disabled("This test is flaky and given that the instant seal node does emit less events it seems like this flaking out is not a real danger, it's more a difference in configuration on the server side.")
     void canSubscribe() {
         try (val wsProvider = WsProvider.builder()


### PR DESCRIPTION
This change:
- Fixes the healthcheck issue
- Moves a throw into the `CompletableFuture` context so we can use all the CompletableFuture methods for exception handling without any need for `try`-`catch`.
- Does not break any tests in this repo, `saas-frequency-client`, or `custodial-wallet`
- However, removing a possible `throw` scenario and adding a new type of exception that the `CompletableFuture` may resolve to has the possibility to mess up MeWe, so we may want to increment the version number accordingly and discuss this change with them